### PR TITLE
124: Optimize Search Query

### DIFF
--- a/backend/src/main/kotlin/xyz/elitese/ehrenamtskarte/database/repos/AcceptingStoresRepository.kt
+++ b/backend/src/main/kotlin/xyz/elitese/ehrenamtskarte/database/repos/AcceptingStoresRepository.kt
@@ -8,8 +8,6 @@ import xyz.elitese.ehrenamtskarte.database.PhysicalStores
 
 object AcceptingStoresRepository {
 
-    fun findAll() = AcceptingStoreEntity.all()
-
     fun findByIds(ids: List<Int>) = AcceptingStoreEntity.find {
         AcceptingStores.id inList ids
     }
@@ -19,26 +17,37 @@ object AcceptingStoresRepository {
     // TODO Fulltext search is possible with tsvector in postgres: https://www.compose.com/articles/mastering-postgresql-tools-full-text-search-and-phrase-search/
     // TODO Probably not relevant right now
     fun findBySearch(searchText: String?, categoryIds: List<Int>?): SizedIterable<AcceptingStoreEntity> {
+        val categoryMatcher =
+            if (categoryIds == null)
+                Op.TRUE
+            else
+                Op.build { AcceptingStores.categoryId inList categoryIds }
 
-        val matchCategoryIds = if (categoryIds != null) Op.build { AcceptingStores.categoryId inList categoryIds } else Op.TRUE
-        val matchSearchText = if (searchText != null) {
-            val lowerCaseSearchText = searchText.toLowerCase()
-            Op.build {
-                ((AcceptingStores.name.lowerCase() like "%${lowerCaseSearchText}%") or
-                        (AcceptingStores.description.lowerCase() like "%${lowerCaseSearchText}%") or
-                        exists(PhysicalStores.select(
-                            PhysicalStores.storeId eq AcceptingStores.id and
-                                    exists(Addresses.select(
-                                        Addresses.id eq PhysicalStores.addressId and
-                                                (Addresses.location.lowerCase() like "%${lowerCaseSearchText}%") or
-                                                (Addresses.postalCode.lowerCase() like "%${lowerCaseSearchText}%") or
-                                                (Addresses.street.lowerCase() like "%${lowerCaseSearchText}%")
-                                    ))
-                        )))
-            }
-        } else Op.TRUE
-        return AcceptingStoreEntity.find {
-            matchSearchText.and(matchCategoryIds)
-        }
+        val textMatcher =
+            if (searchText == null)
+                Op.TRUE
+            else
+                OrOp(
+                    listOf(
+                        AcceptingStores.description ilike "%$searchText%",
+                        Addresses.location ilike "%$searchText%",
+                        Addresses.postalCode ilike "%$searchText%",
+                        Addresses.street ilike "%$searchText%"
+                    )
+                )
+
+        return (AcceptingStores leftJoin PhysicalStores leftJoin Addresses)
+            .slice(AcceptingStores.columns)
+            .select(categoryMatcher and textMatcher)
+            .let { AcceptingStoreEntity.wrapRows(it) }
     }
 }
+
+// Postgres' "like" operation uses case sensitive comparison by default.
+// Postgres has a builtin "ilike" operation which does case sensitive comparison.
+
+class InsensitiveLikeOp(expr1: Expression<*>, expr2: Expression<*>) : ComparisonOp(expr1, expr2, "ILIKE")
+
+infix fun <T : String?> Expression<T>.ilike(pattern: String): InsensitiveLikeOp =
+    InsensitiveLikeOp(this, stringParam(pattern))
+

--- a/backend/src/main/kotlin/xyz/elitese/ehrenamtskarte/database/repos/AcceptingStoresRepository.kt
+++ b/backend/src/main/kotlin/xyz/elitese/ehrenamtskarte/database/repos/AcceptingStoresRepository.kt
@@ -29,6 +29,7 @@ object AcceptingStoresRepository {
             else
                 OrOp(
                     listOf(
+                        AcceptingStores.name ilike "%$searchText%",
                         AcceptingStores.description ilike "%$searchText%",
                         Addresses.location ilike "%$searchText%",
                         Addresses.postalCode ilike "%$searchText%",


### PR DESCRIPTION
Closes #124 .

An example query with ```searchText="ab" && categorieIds=[0,1,2]```

Before Optimization (local query time 1701.19 ms):
```sql
SELECT acceptingstores.id, acceptingstores."name", acceptingstores.description, acceptingstores."contactId", acceptingstores."categoryId"
FROM acceptingstores
WHERE
  ((LOWER(acceptingstores."name") LIKE '%ab%') OR (LOWER(acceptingstores.description) LIKE '%ab%') OR EXISTS (SELECT physicalstores.id, physicalstores.coordinates, physicalstores."addressId", physicalstores."storeId" FROM physicalstores WHERE (physicalstores."storeId" = acceptingstores.id) AND EXISTS (SELECT addresses.id, addresses.street, addresses."postalCode", addresses."location", addresses."countryCode" FROM addresses WHERE ((addresses.id = physicalstores."addressId") AND (LOWER(addresses."location") LIKE '%ab%')) OR (LOWER(addresses."postalCode") LIKE '%ab%') OR (LOWER(addresses.street) LIKE '%ab%'))))
  AND (acceptingstores."categoryId" IN (0, 1, 2))
```

After Optimization (local query time 137.69 ms):
```sql
SELECT acceptingstores.id, acceptingstores."name", acceptingstores.description, acceptingstores."contactId", acceptingstores."categoryId"
FROM acceptingstores
LEFT JOIN physicalstores ON acceptingstores.id = physicalstores."storeId"
LEFT JOIN addresses ON addresses.id = physicalstores."addressId"
WHERE 
  (acceptingstores."categoryId" IN (0, 1, 2))
  AND ((acceptingstores."name" ILIKE '%ab%') OR (acceptingstores.description ILIKE '%ab%') OR (addresses."location" ILIKE '%ab%') OR (addresses."postalCode" ILIKE '%ab%') OR (addresses.street ILIKE '%ab%'))
```
