### PR TITLE
Constrain pipeline to Flutter 2.0.6

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -18,7 +18,7 @@ fe_task_without_container_template: &FE_TASK_WITHOUT_CONTAINER_TEMPLATE
 fe_task_template: &FE_TASK_TEMPLATE
   << : *FE_TASK_WITHOUT_CONTAINER_TEMPLATE
   container:
-    image: cirrusci/flutter:latest
+    image: cirrusci/flutter:2.0.6
 
 fe_analyze_task:
   name: "FE: analyze"


### PR DESCRIPTION
This should fix the failing tests. On the long term, we should of course update to the latest version.