### PR TITLE
#360: Use Flutter version 2.0.6

### DIFF
--- a/frontend/.fvm/fvm_config.json
+++ b/frontend/.fvm/fvm_config.json
@@ -1,0 +1,4 @@
+{
+  "flutterSdkVersion": "2.0.6",
+  "flavors": {}
+}

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,5 +1,7 @@
 schema.graphql
 
+.fvm/flutter_sdk
+
 
 # Miscellaneous
 *.class

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,24 @@
+# Flutter App for Android and iOS
+
+## Development
+
+### Flutter Version
+
+Make sure you have Flutter version `2.0.6` installed,
+as we currently depend on Dart Sdk `<2.13.0`.
+
+One way to install a specific version of flutter is through [FVM - Flutter Version Management](https://fvm.app).
+
+To install FVM and the project Flutter version
+* Run the command `flutter pub global activate fvm`.
+* If not already done, you might need to add some flutter directory to your PATH environment. The above command will notify you if this is the case.
+* Make sure you are located in the `frontend` directory. Run `fvm install` to install the correct Flutter version (as specified in `.fvm/fvm_config.json`).
+* For IntelliJ support, select the new Flutter Sdk by:
+  * Open `Settings > Languages & Frameworks > Flutter`.
+  * Change the Flutter Sdk Path to `(project-directory)/frontend/.fvm/flutter_sdk`.
+
+Once installed, you can run any flutter command simply by prefixing it with `fvm`, e.g. `fvm flutter pub get`
+
+To upgrade the flutter version 
+* Run `fvm use x.y.z`
+* Adjust the version specified in `pubspec.yaml`, in `.cirrus.yml` and at the top of this file. 

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -1175,5 +1175,5 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
-  flutter: ">=1.26.0-17.6.pre"
+  dart: ">=2.12.0 <2.13.0"
+  flutter: ">=2.0.6"

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -19,6 +19,7 @@ version: 1.0.0+1
 
 environment:
   sdk: ">=2.7.0 <3.0.0"
+  flutter: 2.0.6
 
 dependencies:
   flutter:


### PR DESCRIPTION
I have noticed after upgrading to the latest flutter version, that our project is not able to `flutter pub get` anymore. It seems the problem is an upgrade of dependencies inside the upgraded dart sdk.
I thought this might be a good time, to pin the flutter version used in the project with [FVM](https://fvm.app)